### PR TITLE
채용공고 검색 중 Sort 지원 확장

### DIFF
--- a/src/main/kotlin/org/lgm/jobboard/jobposting/api/JobPostingController.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/api/JobPostingController.kt
@@ -6,6 +6,8 @@ import org.lgm.jobboard.jobposting.api.response.JobPostingDetailResponse
 import org.lgm.jobboard.jobposting.api.response.JobPostingListResponse
 import org.lgm.jobboard.jobposting.application.dto.CreateJobPostingCommand
 import org.lgm.jobboard.jobposting.application.query.JobPostingSearchCondition
+import org.lgm.jobboard.jobposting.application.query.JobPostingSort
+import org.lgm.jobboard.jobposting.application.query.SortDirection
 import org.lgm.jobboard.jobposting.application.service.JobPostingCommandService
 import org.lgm.jobboard.jobposting.application.service.JobPostingQueryService
 import org.lgm.jobboard.jobposting.domain.type.JobPostingStatus
@@ -54,14 +56,19 @@ class JobPostingController(
 		@RequestParam(required = false) skill: String?,
 		@RequestParam(required = false) status: JobPostingStatus?,
 		@RequestParam(defaultValue = "0") page: Int,
-		@RequestParam(defaultValue = "20") size: Int
+		@RequestParam(defaultValue = "20") size: Int,
+		@RequestParam(required = false) sort: String?,
+		@RequestParam(required = false) direction: String?
 	): JobPostingListResponse {
 		val condition = JobPostingSearchCondition(
 			companyId = companyId,
 			skill = skill,
 			status= status
 		)
-		val page = jobPostingQueryService.search(condition, page, size)
+		val sortKey = JobPostingSort.fromParam(sort)
+		val direction = SortDirection.fromParam(direction)
+
+		val page = jobPostingQueryService.search(condition, page, size, sortKey, direction)
 		return JobPostingListResponse.from(page)
 	}
 }

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/api/response/JobPostingDetailResponse.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/api/response/JobPostingDetailResponse.kt
@@ -1,6 +1,6 @@
 package org.lgm.jobboard.jobposting.api.response
 
-import org.lgm.jobboard.jobposting.application.dto.JobPostingDetailView
+import org.lgm.jobboard.jobposting.application.query.JobPostingDetailView
 import java.time.OffsetDateTime
 
 data class JobPostingDetailResponse(

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/port/JobPostingQueryPort.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/port/JobPostingQueryPort.kt
@@ -1,6 +1,6 @@
 package org.lgm.jobboard.jobposting.application.port
 
-import org.lgm.jobboard.jobposting.application.dto.JobPostingDetailView
+import org.lgm.jobboard.jobposting.application.query.JobPostingDetailView
 import org.lgm.jobboard.jobposting.application.query.JobPostingListItemView
 import org.lgm.jobboard.jobposting.application.query.JobPostingSearchCondition
 import org.springframework.data.domain.Page

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/CompanyView.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/CompanyView.kt
@@ -1,4 +1,4 @@
-package org.lgm.jobboard.jobposting.application.dto
+package org.lgm.jobboard.jobposting.application.query
 
 data class CompanyView(
 	val companyId: Long,

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingDetailView.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingDetailView.kt
@@ -1,4 +1,4 @@
-package org.lgm.jobboard.jobposting.application.dto
+package org.lgm.jobboard.jobposting.application.query
 
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingSort.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingSort.kt
@@ -1,0 +1,15 @@
+package org.lgm.jobboard.jobposting.application.query
+
+enum class JobPostingSort(val property: String) {
+	CREATED_AT("created_at"),
+	TITLE("title");
+
+	companion object {
+		fun fromParam(value: String?): JobPostingSort =
+			when (value?.trim()?.lowercase()) {
+				null, "", "createdat", "created_at" -> CREATED_AT
+				"title" -> TITLE
+				else -> throw IllegalArgumentException("unsupported sort: $value")
+			}
+	}
+}

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/SortDirection.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/SortDirection.kt
@@ -1,0 +1,15 @@
+package org.lgm.jobboard.jobposting.application.query
+
+enum class SortDirection {
+	ASC,
+	DESC;
+
+	companion object {
+		fun fromParam(value: String?): SortDirection =
+			when (value?.trim()?.lowercase()) {
+				"asc" -> ASC
+				null, "", "desc" -> DESC
+				else -> throw IllegalArgumentException("unsupported sort: $value")
+			}
+	}
+}

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/service/JobPostingQueryService.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/service/JobPostingQueryService.kt
@@ -1,10 +1,7 @@
 package org.lgm.jobboard.jobposting.application.service
 
 import org.lgm.jobboard.jobposting.application.port.JobPostingQueryPort
-import org.lgm.jobboard.jobposting.application.query.JobPostingDetailView
-import org.lgm.jobboard.jobposting.application.query.JobPostingListItemView
-import org.lgm.jobboard.jobposting.application.query.JobPostingSearchCondition
-import org.lgm.jobboard.jobposting.application.query.PageView
+import org.lgm.jobboard.jobposting.application.query.*
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -20,9 +17,22 @@ class JobPostingQueryService(
 	}
 
 	@Transactional(readOnly = true)
-	fun search(condition: JobPostingSearchCondition, page: Int, size: Int): PageView<JobPostingListItemView> {
+	fun search(
+		condition: JobPostingSearchCondition,
+		page: Int,
+		size: Int,
+		sort: JobPostingSort,
+		dir: SortDirection
+	): PageView<JobPostingListItemView> {
 		val safeSize = size.coerceIn(1, 100)
-		val pageable = PageRequest.of(page.coerceAtLeast(0), safeSize, Sort.by(Sort.Direction.DESC, "createdAt"))
+		val safePage = page.coerceAtLeast(0)
+
+		val direction = if (dir == SortDirection.ASC) Sort.Direction.ASC else Sort.Direction.DESC
+		val pageable = PageRequest.of(
+			safePage,
+			safeSize,
+			Sort.by(direction, sort.property)
+		)
 
 		val resultPage = jobPostingQueryPort.search(condition, pageable)
 		return PageView(

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/service/JobPostingQueryService.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/service/JobPostingQueryService.kt
@@ -1,7 +1,7 @@
 package org.lgm.jobboard.jobposting.application.service
 
-import org.lgm.jobboard.jobposting.application.dto.JobPostingDetailView
 import org.lgm.jobboard.jobposting.application.port.JobPostingQueryPort
+import org.lgm.jobboard.jobposting.application.query.JobPostingDetailView
 import org.lgm.jobboard.jobposting.application.query.JobPostingListItemView
 import org.lgm.jobboard.jobposting.application.query.JobPostingSearchCondition
 import org.lgm.jobboard.jobposting.application.query.PageView

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/adapter/JobPostingQueryAdapter.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/adapter/JobPostingQueryAdapter.kt
@@ -1,11 +1,7 @@
 package org.lgm.jobboard.jobposting.infra.persistence.adapter
 
-import org.lgm.jobboard.jobposting.application.dto.CompanyView
-import org.lgm.jobboard.jobposting.application.dto.JobPostingDetailView
 import org.lgm.jobboard.jobposting.application.port.JobPostingQueryPort
-import org.lgm.jobboard.jobposting.application.query.CompanySummaryView
-import org.lgm.jobboard.jobposting.application.query.JobPostingListItemView
-import org.lgm.jobboard.jobposting.application.query.JobPostingSearchCondition
+import org.lgm.jobboard.jobposting.application.query.*
 import org.lgm.jobboard.jobposting.infra.persistence.JobPostingEntity
 import org.lgm.jobboard.jobposting.infra.persistence.JobPostingRepository
 import org.lgm.jobboard.jobposting.infra.persistence.JobPostingSkillRepository


### PR DESCRIPTION
### 내용
- 채용공고 필터/검색 API에 Sort 파라미터 지원하도록 기능 확장

### Parent PR
- #9 