### PR TITLE
feat: Outbox poller 스케줄러 정리

### DIFF
--- a/src/main/kotlin/org/lgm/jobboard/common/config/SchedulingConfig.kt
+++ b/src/main/kotlin/org/lgm/jobboard/common/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package org.lgm.jobboard.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/src/main/kotlin/org/lgm/jobboard/outbox/application/handler/LoggingOutboxEventHandler.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/application/handler/LoggingOutboxEventHandler.kt
@@ -1,0 +1,23 @@
+package org.lgm.jobboard.outbox.application.handler
+
+import org.lgm.jobboard.outbox.application.query.OutboxEventView
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class LoggingOutboxEventHandler : OutboxEventHandler {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	override fun canHandle(event: OutboxEventView): Boolean {
+		// 전부 처리한다고 가정
+		return true
+	}
+
+	override fun handle(event: OutboxEventView) {
+		// TODO: 추후 OpenSearch 색인 호출이 들어갈 것
+		log.info(
+			"Handled outbox event. id={}, aggregateType={}, aggregateId={}, eventType={}, payload={}",
+			event.id, event.aggregateType, event.aggregateId, event.eventType, event.payloadJson
+		)
+	}
+}

--- a/src/main/kotlin/org/lgm/jobboard/outbox/application/handler/OutboxEventHandler.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/application/handler/OutboxEventHandler.kt
@@ -1,0 +1,9 @@
+package org.lgm.jobboard.outbox.application.handler
+
+import org.lgm.jobboard.outbox.application.query.OutboxEventView
+
+interface OutboxEventHandler {
+	fun canHandle(event: OutboxEventView): Boolean
+
+	fun handle(event: OutboxEventView)
+}

--- a/src/main/kotlin/org/lgm/jobboard/outbox/application/port/OutboxCommandPort.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/application/port/OutboxCommandPort.kt
@@ -2,6 +2,7 @@ package org.lgm.jobboard.outbox.application.port
 
 import org.lgm.jobboard.outbox.domain.type.AggregateType
 import org.lgm.jobboard.outbox.domain.type.EventType
+import java.time.OffsetDateTime
 
 interface OutboxCommandPort {
 	fun enqueue(
@@ -10,4 +11,12 @@ interface OutboxCommandPort {
 		eventType: EventType,
 		payloadJson: String
 	)
+
+	fun markProcessing(id: Long)
+
+	fun markDone(id: Long)
+
+	fun markFailed(id: Long, errorMessage: String, nextAvailableAt: OffsetDateTime)
+
+	fun requeue(id: Long, nextAvailableAt: OffsetDateTime)
 }

--- a/src/main/kotlin/org/lgm/jobboard/outbox/application/port/OutboxQueryPort.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/application/port/OutboxQueryPort.kt
@@ -1,0 +1,10 @@
+package org.lgm.jobboard.outbox.application.port
+
+import org.lgm.jobboard.outbox.application.query.OutboxEventView
+import java.time.OffsetDateTime
+
+interface OutboxQueryPort {
+	fun findDueEventIds(now: OffsetDateTime, limit: Int): List<Long>
+
+	fun lockById(id: Long): OutboxEventView?    // 비관적 락으로 한 건씩 가져오기
+}

--- a/src/main/kotlin/org/lgm/jobboard/outbox/application/query/OutboxEventView.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/application/query/OutboxEventView.kt
@@ -1,0 +1,14 @@
+package org.lgm.jobboard.outbox.application.query
+
+import java.time.OffsetDateTime
+
+data class OutboxEventView(
+	val id: Long,
+	val aggregateType: String,
+	val aggregateId: Long,
+	val eventType: String,
+	val payloadJson: String,
+	val status: String,
+	val attempts: Int,
+	val availableAt: OffsetDateTime
+)

--- a/src/main/kotlin/org/lgm/jobboard/outbox/application/service/OutboxPollingService.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/application/service/OutboxPollingService.kt
@@ -1,0 +1,66 @@
+package org.lgm.jobboard.outbox.application.service
+
+import org.lgm.jobboard.outbox.application.handler.OutboxEventHandler
+import org.lgm.jobboard.outbox.application.port.OutboxCommandPort
+import org.lgm.jobboard.outbox.application.port.OutboxQueryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.OffsetDateTime
+import kotlin.math.min
+
+@Service
+class OutboxPollingService(
+	private val outboxQueryPort: OutboxQueryPort,
+	private val outboxCommandPort: OutboxCommandPort,
+	private val handlers: List<OutboxEventHandler>,
+	transactionManager: PlatformTransactionManager
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+	private val tx = TransactionTemplate(transactionManager)
+
+	fun pollOnce(batchSize: Int = 50) {
+		val now = OffsetDateTime.now()
+		val ids = outboxQueryPort.findDueEventIds(now, batchSize)
+		if (ids.isEmpty()) return
+
+		ids.forEach { id ->
+			// 이벤트 1건당 트랜잭션 분리
+			tx.executeWithoutResult {
+				processOne(id)
+			}
+		}
+	}
+
+	fun processOne(id: Long) {
+		val locked = outboxQueryPort.lockById(id) ?: return
+
+		// 이미 누가 처리 중이거나 상태가 변할 수 있음 (경쟁 상태 방어)
+		// 여기서 DB row Lock이 잡혀 있지만 체크
+		outboxCommandPort.markProcessing(id)
+
+		try {
+			val handler = handlers.firstOrNull { it.canHandle(locked) }
+				?: throw IllegalStateException("No handler found for outbox event id=$id")
+
+			handler.handle(event = locked)
+		} catch (e: Exception) {
+			val attemps = locked.attempts + 1
+			val next = computeBackoff(OffsetDateTime.now(), attemps)
+			val msg = e.message ?: e.javaClass.simpleName
+			log.warn("Outbox handling failed. id={}, attemps={}, nextAvailableAt={}, error={}",
+				id, attemps, next, msg)
+			outboxCommandPort.markFailed(id, msg, next)
+		}
+	}
+
+	/**
+	 * 단순 backoff: 2^attemps 초 (최대 5분 캡)
+	 * 예: 1회=2s, 2회=4s, 3회=8s ... 최대 300s
+	 */
+	private fun computeBackoff(now: OffsetDateTime, attempts: Int): OffsetDateTime {
+		val seconds = min(300, 1 shl min(attempts, 8)) // 2^attempts, overflow 방지
+		return now.plusSeconds(seconds.toLong())
+	}
+}

--- a/src/main/kotlin/org/lgm/jobboard/outbox/infra/persistence/OutboxEventRepository.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/infra/persistence/OutboxEventRepository.kt
@@ -3,6 +3,7 @@ package org.lgm.jobboard.outbox.infra.persistence
 import jakarta.persistence.LockModeType
 import org.lgm.jobboard.outbox.domain.type.OutboxStatus
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -24,6 +25,18 @@ interface OutboxEventRepository : JpaRepository<OutboxEventEntity, Long> {
 		@Param("now") now: OffsetDateTime,
 		pageable: PageRequest
 	): List<OutboxEventEntity>
+
+	// 활성화 일자인 PENDING 상태의 이벤트 페이징 조회
+	@Query(
+		"""
+		select oe.id
+		from OutboxEventEntity oe
+		where oe.status = 'PENDING'
+			and oe.availableAt <= :now
+		order by oe.createdAt asc
+		"""
+	)
+	fun findDueIds(@Param("now") now: OffsetDateTime, pageable: Pageable): List<Long>
 
 	// 멀티 인스턴스 확장 고려 비관적 락
 	@Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/kotlin/org/lgm/jobboard/outbox/infra/persistence/adapter/OutboxCommandAdapter.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/infra/persistence/adapter/OutboxCommandAdapter.kt
@@ -6,6 +6,8 @@ import org.lgm.jobboard.outbox.domain.type.EventType
 import org.lgm.jobboard.outbox.infra.persistence.OutboxEventEntity
 import org.lgm.jobboard.outbox.infra.persistence.OutboxEventRepository
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
 
 @Component
 class OutboxCommandAdapter(
@@ -25,5 +27,29 @@ class OutboxCommandAdapter(
 				payload = payloadJson
 			)
 		)
+	}
+
+	@Transactional
+	override fun markProcessing(id: Long) {
+		val event = outboxEventRepository.findById(id).orElseThrow()
+		event.markProcessing()
+	}
+
+	@Transactional
+	override fun markDone(id: Long) {
+		val event = outboxEventRepository.findById(id).orElseThrow()
+		event.markDone()
+	}
+
+	@Transactional
+	override fun markFailed(id: Long, errorMessage: String, nextAvailableAt: OffsetDateTime) {
+		val event = outboxEventRepository.findById(id).orElseThrow()
+		event.markFailed(errorMessage, nextAvailableAt)
+	}
+
+	@Transactional
+	override fun requeue(id: Long, nextAvailableAt: OffsetDateTime) {
+		val event = outboxEventRepository.findById(id).orElseThrow()
+		event.requeue(nextAvailableAt)
 	}
 }

--- a/src/main/kotlin/org/lgm/jobboard/outbox/infra/persistence/adapter/OutboxQueryAdapter.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/infra/persistence/adapter/OutboxQueryAdapter.kt
@@ -1,0 +1,35 @@
+package org.lgm.jobboard.outbox.infra.persistence.adapter
+
+import org.lgm.jobboard.outbox.application.port.OutboxQueryPort
+import org.lgm.jobboard.outbox.application.query.OutboxEventView
+import org.lgm.jobboard.outbox.infra.persistence.OutboxEventRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import java.time.OffsetDateTime
+
+@Component
+class OutboxQueryAdapter(
+	private val outboxEventRepository: OutboxEventRepository
+) : OutboxQueryPort {
+	override fun findDueEventIds(
+		now: OffsetDateTime,
+		limit: Int
+	): List<Long> {
+		val pageable = PageRequest.of(0, limit.coerceIn(1, 200))
+		return outboxEventRepository.findDueIds(now, pageable)
+	}
+
+	override fun lockById(id: Long): OutboxEventView? {
+		val event = outboxEventRepository.lockById(id) ?: return null
+		return OutboxEventView(
+			id = event.id!!,
+			aggregateType = event.aggregateType.name,
+			aggregateId = event.aggregateId,
+			eventType = event.eventType.name,
+			payloadJson = event.payload,
+			status = event.status.name,
+			attempts = event.attempts,
+			availableAt = event.availableAt
+		)
+	}
+}

--- a/src/main/kotlin/org/lgm/jobboard/outbox/infra/scheduler/OutboxScheduler.kt
+++ b/src/main/kotlin/org/lgm/jobboard/outbox/infra/scheduler/OutboxScheduler.kt
@@ -1,0 +1,15 @@
+package org.lgm.jobboard.outbox.infra.scheduler
+
+import org.lgm.jobboard.outbox.application.service.OutboxPollingService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class OutboxScheduler(
+	private val pollingService: OutboxPollingService
+) {
+	@Scheduled(fixedDelayString = "\${app.outbox.poll-interval-ms:1000}")
+	fun poll() {
+		pollingService.pollOnce(batchSize = 50)
+	}
+}

--- a/src/main/resources/application.example.yml
+++ b/src/main/resources/application.example.yml
@@ -1,3 +1,7 @@
+app:
+  outbox:
+    poll-interval-ms: 1000
+
 spring:
   application:
     name: job-board


### PR DESCRIPTION
### 내용
- 우선 가짜 인덱서(로깅 이벤트 핸들러) 로 구성
- `outbox event`에서 `PENDING && avaliable_at <= now()` 를 batch로 조회
- 각 이벤트를 `PROCESSING` 으로 바꾸고 처리
- 성공: `DONE`
- 실패: `FAILED`, `attemps++`, `available_at` backoff