### PR TITLE
RDB 조회하는 검색 API 키워드 파라미터 추가 & K6 검색 기능 성능 테스트 추가

### DIFF
--- a/k6/perf/opensearch.js
+++ b/k6/perf/opensearch.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+export const options = {
+	scenarios: {
+		// OpenSearch
+		os: {
+			executor: 'constant-vus',
+			vus: 1000,
+			duration: '20s',
+			exec: 'os',
+		},
+	},
+};
+
+export function os() {
+	const res = http.get('http://localhost:8080/api/search/job-postings?q=Java&status=OPEN&page=0&size=20', {
+		headers: { Connection: 'Keep-alive' },
+	});
+	check(res, { 'os status 200': (r) => r.status === 200 });
+	sleep(0.2);
+}

--- a/k6/perf/rdb.js
+++ b/k6/perf/rdb.js
@@ -1,0 +1,23 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+export const options = {
+	scenarios: {
+		// RDB
+		rdb: {
+			executor: 'constant-vus',
+			vus: 1000,
+			duration: '20s',
+			exec: 'rdb',
+		},
+	},
+};
+
+export function rdb() {
+	const res = http.get('http://localhost:8080/api/job-postings?q=Java&status=OPEN&page=0&size=20', {
+		headers: { Connection: 'Keep-alive' },
+	});
+
+	check(res, { 'rdb status 200': (r) => r.status === 200 });
+	sleep(0.2);
+}

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/api/JobPostingController.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/api/JobPostingController.kt
@@ -52,6 +52,7 @@ class JobPostingController(
 
 	@GetMapping
 	fun search(
+		@RequestParam(required = false) q: String?,
 		@RequestParam(required = false) companyId: Long?,
 		@RequestParam(required = false) skill: String?,
 		@RequestParam(required = false) status: JobPostingStatus?,
@@ -61,6 +62,7 @@ class JobPostingController(
 		@RequestParam(required = false) direction: String?
 	): JobPostingListResponse {
 		val condition = JobPostingSearchCondition(
+			q = q,
 			companyId = companyId,
 			skill = skill,
 			status= status

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingSearchCondition.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingSearchCondition.kt
@@ -3,6 +3,7 @@ package org.lgm.jobboard.jobposting.application.query
 import org.lgm.jobboard.jobposting.domain.type.JobPostingStatus
 
 data class JobPostingSearchCondition(
+	val q: String?, // 키워드
 	val companyId: Long? = null,
 	val skill: String? = null,
 	val status: JobPostingStatus? = null

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingSort.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/application/query/JobPostingSort.kt
@@ -1,7 +1,7 @@
 package org.lgm.jobboard.jobposting.application.query
 
 enum class JobPostingSort(val property: String) {
-	CREATED_AT("created_at"),
+	CREATED_AT("createdAt"),
 	TITLE("title");
 
 	companion object {

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/JobPostingRepository.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/JobPostingRepository.kt
@@ -34,11 +34,13 @@ interface JobPostingRepository : JpaRepository<JobPostingEntity, Long> {
 		"""
 		select jp.id
 		from JobPostingEntity jp
-		where (:companyId is null or jp.company.id = :companyId)
+		where (:q is null or (jp.title like %:q% or jp.description like %:q%))
+			and (:companyId is null or jp.company.id = :companyId)
 			and (:status is null or jp.status = :status)
 		"""
 	)
 	fun searchIds(
+		@Param("q") q: String?,
 		@Param("companyId") companyId: Long?,
 		@Param("status") status: JobPostingStatus?,
 		pageable: Pageable

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/adapter/JobPostingQueryAdapter.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/adapter/JobPostingQueryAdapter.kt
@@ -54,6 +54,7 @@ class JobPostingQueryAdapter(
 		val idPage: Page<Long> =
 			if (skill == null) {
 				jobPostingRepository.searchIds(
+					q = condition.q,
 					companyId = condition.companyId,
 					status = condition.status,
 					pageable = pageable

--- a/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/adapter/JobPostingQueryAdapter.kt
+++ b/src/main/kotlin/org/lgm/jobboard/jobposting/infra/persistence/adapter/JobPostingQueryAdapter.kt
@@ -7,6 +7,7 @@ import org.lgm.jobboard.jobposting.infra.persistence.JobPostingRepository
 import org.lgm.jobboard.jobposting.infra.persistence.JobPostingSkillRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
@@ -62,7 +63,10 @@ class JobPostingQueryAdapter(
 					companyId = condition.companyId,
 					status = condition.status,
 					skill = skill,
-					pageable = pageable
+					pageable = PageRequest.of(
+						pageable.pageNumber,
+						pageable.pageSize
+					)
 				)
 			}
 


### PR DESCRIPTION
### 내용
- RDB 조회하는 검색 API 키워드 파라미터 추가
    - `q` 파라미터 추가
    - 공고 제목 & description에서 키워드가 포함된 내용 검색
- RDB 조회 검색 API 로직에서 Pageable 정렬 이슈 수정
    - `org.hibernate.query.sqm.UnknownPathException: Could not resolve attribute 'created_at'`
    - `created_at` 필드가 없는 엔티티에서 `created_at` 조건으로 정렬하려고 하는 이슈 수정
- OpenSearch 검색 및 RDB 조회 검색 기능 K6 성능 테스트 스크립트 추가